### PR TITLE
Change subshell handling to enable exit code be set

### DIFF
--- a/test01.sh
+++ b/test01.sh
@@ -9,7 +9,7 @@ echo " == #1 - UDPv4 reachability == "
 
 err=0
 
-dig NS ${1} +short | while read server; do
+while read server; do
   ipaddr=$(dig ${server} A +short)
 
   echo "Server: ${server} (${ipaddr})"
@@ -22,6 +22,6 @@ dig NS ${1} +short | while read server; do
   else
     echo "OK"
   fi
-done
+done <<< "$(dig NS $1 +short +nocookie)"
 
 exit ${err}

--- a/test02.sh
+++ b/test02.sh
@@ -9,7 +9,7 @@ echo " == #2 - UDPv6 reachability == "
 
 err=0
 
-dig NS ${1} +short | while read server; do
+while read server; do
   ipaddr=$(dig ${server} AAAA +short)
 
   echo "Server: ${server} (${ipaddr})"
@@ -22,6 +22,6 @@ dig NS ${1} +short | while read server; do
   else
     echo "OK"
   fi
-done
+done <<< "$(dig NS $1 +short +nocookie)"
 
 exit ${err}

--- a/test03.sh
+++ b/test03.sh
@@ -9,7 +9,7 @@ echo " == #3 - TCPv4 reachability == "
 
 err=0
 
-dig NS ${1} +short | while read server; do
+while read server; do
   ipaddr=$(dig ${server} A +short)
 
   echo "Server: ${server} (${ipaddr})"
@@ -22,6 +22,6 @@ dig NS ${1} +short | while read server; do
   else
     echo "OK"
   fi
-done
+done <<< "$(dig NS $1 +short +nocookie)"
 
 exit ${err}

--- a/test04.sh
+++ b/test04.sh
@@ -9,7 +9,7 @@ echo " == #4 - TCPv6 reachability == "
 
 err=0
 
-dig NS ${1} +short | while read server; do
+while read server; do
   ipaddr=$(dig ${server} AAAA +short)
 
   echo "Server: ${server} (${ipaddr})"
@@ -22,6 +22,6 @@ dig NS ${1} +short | while read server; do
   else
     echo "OK"
   fi
-done
+done <<< "$(dig NS $1 +short +nocookie)"
 
 exit ${err}

--- a/test05.sh
+++ b/test05.sh
@@ -11,16 +11,16 @@ echo " == #5 - EDNS0 response size == "
 err=0
 ednspolicy=1232
 
-dig NS ${1} +short | while read server; do
-  echo "Server: ${server} "
+while read server; do
+  printf "Server: ${server} "
   ednsbuf=$(dig @${server} ${1} | grep "; EDNS:" | cut -d " " -f 7)
 
   if [ "${ednsbuf}" -eq "${ednspolicy}" ]; then
-    echo " EDNS0-Bufsize is ${ednsbuf}, good "
+    printf " EDNS0-Bufsize is ${ednsbuf}, good\n"
   else
     err=1
-    echo " EDNS0-Bufsize is ${ednsbuf}, out of policy range "
+    printf " EDNS0-Bufsize is ${ednsbuf}, out of policy range\n"
   fi
-done
+done <<< "$(dig +short NS $1)"
 
 exit ${err}

--- a/test08.sh
+++ b/test08.sh
@@ -16,9 +16,7 @@ echo " == #8 - SOA serial == "
 err=0
 oldsoaserial="0"
 
-dig ${1} +nssearch | while read serverres; do
-  soaserial=$(echo ${serverres} | cut -d ' ' -f 4)
-
+while read soa mname rname soaserial rest; do
   if [ "${oldsoaserial}" -eq "0" ]; then
     oldsoaserial=${soaserial}
   else
@@ -29,6 +27,6 @@ dig ${1} +nssearch | while read serverres; do
       echo "Mismatch for ${soaserial} != ${oldsoaserial}"
     fi
   fi
-done
+done <<< "$(dig $1 +nssearch +nocookie)"
 
 exit ${err}

--- a/test09.sh
+++ b/test09.sh
@@ -9,16 +9,16 @@ echo " == #9 - AA-Flag == "
 
 err=0
 
-dig NS ${1} +short | while read server; do
-  echo "Server: ${server} "
+while read server; do
+  printf "Server: ${server} "
   aaflag=$(dig @${server} ${1} SOA +norec | grep ";; flags" | cut -d " " -f 4 | cut -b 1-2)
 
   if [ "${aaflag}" = "aa" ]; then
-    echo " AA-Flag found, good "
+    printf " AA-Flag found, good\n"
   else
     err=1
-    echo " no AA-Flag, Server not authoritative "
+    printf " no AA-Flag, Server not authoritative\n"
   fi
-done
+done <<< "$(dig NS $1 +short)"
 
 exit ${err}

--- a/test13.sh
+++ b/test13.sh
@@ -17,24 +17,24 @@ else
   echo "First run. This result won't be meaningful until the next run.";
 fi
 
-ds=$(dig ${1} DS +short)
+ds=$(dig ${1} DS +short +nocookie)
 echo "${ds}" > $0.$1.saved.dscontent
 
-dscount=$(dig ${1} DS +short | wc -l)
+dscount=$(dig ${1} DS +short +nocookie | wc -l)
 echo "${dscount}" > $0.$1.saved.dscount
 
 if [ "${ds}" != "${oldds}" ]; then
   err=1
   echo "Warning: DS-Record has changed!"
 else
-  echo "OK: DS-Record is the same as last time tested!"
+  echo "OK: DS-Record is the same as last time tested."
 fi
 
 if [ "${dscount}" != "${olddscount}" ]; then
   err=1
-  echo "Warning: number of DS-Record has changed!"
+  echo "Warning: number of DS-Records has changed!"
 else
-  echo "OK: number of DS-Record is the same as last time tested!"
+  echo "OK: number of DS-Records is the same as last time tested."
 fi
 
 exit ${err}

--- a/test14.sh
+++ b/test14.sh
@@ -8,14 +8,14 @@
 echo " == #14 - DS Records and KSK == "
 
 if [ "$1" = "" ]; then
-  echo "This test fails without param. Exiting..."
+  echo "This test fails without domain param. Exiting..."
   exit 1
 fi
 
 err=0
 
-dskeyid=$(dig ${1} DS +short +cd | cut -d " " -f 1 | tail -1)
-rrsigkeyid=$(dig ${1} DNSKEY +dnssec +short +cd | egrep "^DNSKEY" | grep "${dskeyid}" | cut -d ' ' -f 7)
+dskeyid=$(dig ${1} DS +short +cd +nocookie | cut -d " " -f 1 | tail -1)
+rrsigkeyid=$(dig ${1} DNSKEY +dnssec +short +cd +nocookie | egrep "^DNSKEY" | grep "${dskeyid}" | cut -d ' ' -f 7)
 
 if [ "${dskeyid}" != "${rrsigkeyid}" ]; then
   err=1

--- a/test15.sh
+++ b/test15.sh
@@ -14,15 +14,15 @@ else
 fi
 
 err=0
-dnskeycount=$(dig ${1} DNSKEY +cd +dnssec | egrep "DNSKEY.*2" | grep -v "RRSIG" | wc -l)
+dnskeycount=$(dig ${1} DNSKEY +cd +dnssec +nocookie | egrep "DNSKEY.*2" | grep -v "RRSIG" | wc -l)
 
 echo "${dnskeycount}" > $0.$1.saved.dnskeycount
 
 if [ "${dnskeycount}" != "${olddnskeycount}" ]; then
   err=1
-  echo "Warning: Number of DNSKEY-Record has changed!"
+  echo "Warning: Number of DNSKEY-Records has changed!"
 else
-  echo "OK: Number of DNSKEY-Record is the same as with last test!"
+  echo "OK: Number of DNSKEY-Records is the same as with last test."
 fi
 
 exit ${err}

--- a/test17.sh
+++ b/test17.sh
@@ -12,13 +12,13 @@ echo " == #17 - Recursion check == "
 err=0
 
 dig NS ${1} +short | while read server; do
-  echo "Server: ${server} "
+  printf "Server: ${server} "
 
   if dig ${1} SOA @${server} | awk '/;; flags:/' | grep -q " ra"; then
     err=1
-    echo " Recursion enabled, bad if this is an authoritative server "
+    printf " Recursion enabled, bad if this is an authoritative server\n"
   else
-    echo " Recursion disabled, good "
+    printf " Recursion disabled, good\n"
   fi
 done
 

--- a/test18.sh
+++ b/test18.sh
@@ -9,16 +9,16 @@ echo " == #18 - NSEC3 check == "
 
 err=0
 
-dig NS ${1} +short | while read server; do
-  echo "Server: ${server} "
-  val=$(dig NSEC3PARAM ${1} @${server} +short);
+while read server; do
+  printf "Server: ${server} "
+  val=$(dig NSEC3PARAM ${1} @${server} +short +nocookie);
 
   if [ "${val}" != "" ]; then
-    echo " NSEC3 enabled, good "
+    printf " NSEC3 enabled, good\n"
   else
     err=1
-    echo " NSEC3 not available "
+    printf " NSEC3 not available\n"
   fi
-done
+done <<< "$(dig NS $1 +short +nocookie)"
 
 exit ${err}


### PR DESCRIPTION
- replace `| while read' behavior so that err variable is correctly set
  on failure
- add +nocookie as its output can interfere with scripts
- address a few typos
- replace echo(1) by printf(1) in cases of multi-line outputs